### PR TITLE
Fix camera starting orientation

### DIFF
--- a/src/hooks/useCameraControls.ts
+++ b/src/hooks/useCameraControls.ts
@@ -22,10 +22,10 @@ interface CameraSettings {
 }
 
 const DEFAULT_CAMERA_STATE: CameraState = {
-  // Centered slightly above the grid looking down from an isometric angle
-  position: { x: 0, y: 15, z: 15 },
-  // Rotation is handled by the isometric projection so start at zero
-  rotation: { pitch: 0, yaw: 0 },
+  // Start from the opposite side of the grid looking toward the center
+  position: { x: 0, y: 15, z: -15 },
+  // Rotate 180° so the camera faces the grid correctly
+  rotation: { pitch: 0, yaw: 180 },
   zoom: 0.8,
 };
 


### PR DESCRIPTION
## Summary
- adjust the default camera state to start from the opposite side facing the grid

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d41f4e5dc8329abdaae52051d2570