### PR TITLE
Adjust projection and camera limits

### DIFF
--- a/src/components/SimulationGrid.tsx
+++ b/src/components/SimulationGrid.tsx
@@ -124,12 +124,13 @@ const SimulationGrid: React.FC<SimulationGridProps> = ({
   };
   
   // Convert grid coordinates to projected screen coordinates with camera transformations
-  const gridToProjected = (gridX: number, gridY: number, height: number = 0): ProjectedPoint => {
+  const gridToProjected = (gridX: number, gridY: number, elevation: number = 0): ProjectedPoint => {
     const cellWorldSize = 1;
+    const verticalScale = 0.5 * cellWorldSize;
     
     // Convert to 3D world coordinates
     let worldX = gridX * cellWorldSize - (width * cellWorldSize) / 2;
-    let worldY = height;
+    let worldY = elevation * verticalScale;
     let worldZ = gridY * cellWorldSize - (height * cellWorldSize) / 2;
     
     // Apply inverse camera translation
@@ -600,7 +601,7 @@ const SimulationGrid: React.FC<SimulationGridProps> = ({
       
       const cell = grid[y] && grid[y][x] ? grid[y][x] : null;
       const cellHeight = cell ? cell.height : 0;
-      const projected = gridToProjected(x, y, cellHeight + organism.size * 0.1);
+      const projected = gridToProjected(x, y, cellHeight + organism.size * 0.5);
       drawableObjects.push({
         type: 'organism',
         gridX: x,

--- a/src/hooks/useCameraControls.ts
+++ b/src/hooks/useCameraControls.ts
@@ -19,6 +19,8 @@ interface CameraSettings {
   zoomSpeed: number;
   mouseSensitivity: number;
   damping: number;
+  maxPitchUp: number;
+  maxPitchDown: number;
 }
 
 const DEFAULT_CAMERA_STATE: CameraState = {
@@ -35,6 +37,8 @@ const DEFAULT_SETTINGS: CameraSettings = {
   zoomSpeed: 0.1,
   mouseSensitivity: 0.5,
   damping: 0.9,
+  maxPitchUp: 60,
+  maxPitchDown: -10,
 };
 
 export function useCameraControls(
@@ -183,7 +187,7 @@ export function useCameraControls(
       setCameraState(prev => ({
         ...prev,
         rotation: {
-          pitch: Math.max(-89, Math.min(89, prev.rotation.pitch + rotationDelta.pitch)),
+          pitch: Math.max(config.maxPitchDown, Math.min(config.maxPitchUp, prev.rotation.pitch + rotationDelta.pitch)),
           yaw: (prev.rotation.yaw + rotationDelta.yaw) % 360,
         },
       }));
@@ -191,7 +195,7 @@ export function useCameraControls(
     
     mouseState.current.lastX = e.clientX;
     mouseState.current.lastY = e.clientY;
-  }, [config.mouseSensitivity, cameraState.zoom]);
+  }, [config.mouseSensitivity, config.maxPitchDown, config.maxPitchUp, cameraState.zoom]);
   
   const handleMouseUp = useCallback((e: MouseEvent) => {
     if (!canvasRef.current) return;
@@ -275,7 +279,7 @@ export function useCameraControls(
           z: prev.position.z + velocities.current.position.z,
         },
         rotation: {
-          pitch: Math.max(-89, Math.min(89, prev.rotation.pitch + velocities.current.rotation.pitch)),
+          pitch: Math.max(config.maxPitchDown, Math.min(config.maxPitchUp, prev.rotation.pitch + velocities.current.rotation.pitch)),
           yaw: (prev.rotation.yaw + velocities.current.rotation.yaw) % 360,
         },
       }));


### PR DESCRIPTION
## Summary
- scale vertical component in `gridToProjected`
- position organisms half above the ground
- add camera pitch limits and expose them via settings

## Testing
- `npm run build`
- `npm run lint` *(fails: unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6882cc99cd608329bcfc84db8d22f567